### PR TITLE
compatibility with Ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
+gem "webrick"


### PR DESCRIPTION
Added `gem "webrick"` to Gemfile for compatibility with Ruby 3.0.0. I was trying to build the site locally, but it kept failing. According to the [documentation](https://jekyllrb.com/docs/) if that is not added then I cannot build the site. Should I not be using any version beyond Ruby 2.X?